### PR TITLE
[SpedFiscal] H010 - COD_CTA

### DIFF
--- a/SpedBr/SpedBr.SpedFiscal/BlocoH.cs
+++ b/SpedBr/SpedBr.SpedFiscal/BlocoH.cs
@@ -127,7 +127,7 @@ namespace SpedBr.SpedFiscal
             /// <summary>
             ///     Código da conta analítica contábil debitada/creditada
             /// </summary>
-            [SpedCampos(10, "COD_CTA", "C", 0, 0, false)]
+            [SpedCampos(10, "COD_CTA", "C", int.MaxValue, 0, false)]
             public string CodCta { get; set; }
 
             /// <summary>


### PR DESCRIPTION
BlocoH, registro H010, campo COD_CTA estava com tamanh máximo 0, fazendo com que o campo saisse em branco mesmo quando informado.